### PR TITLE
Add additional swagger generator options

### DIFF
--- a/README.md
+++ b/README.md
@@ -27,6 +27,23 @@ yarn global add soap-converter
   <img src="https://github.com/buianhthang/soap-converter/raw/master/example.png" alt="png">
 </p>
 
+### Command Line Options
+
+    Usage: soap-converter [options]
+
+    Options:
+      -i, --input <url>                               wsdl url (e.g. http://example.com/service.svc?wsdl)
+      -t, --target <Postman|SwaggerJSON|SwaggerYAML>  target type
+      -o, --output <file>                             output file (e.g. ~/output.json)
+      -k, --api-key-header <name>                     specify an apiKey header name (e.g. 'X-API-Key')
+      --use-security                                  enable generating wssecurity
+      --use-ibm-datapower-gateway                     enable IBM DataPower Gateway headers (default: false)
+      --no-examples                                   disable generating examples
+      --no-inline-attributes                          disable inline attributes
+      -h, --help                                      output usage information
+
+Example: `soap-converter --input http://example.com/service.svc\?wsdl --target SwaggerJSON --output ~/service.swagger.json --api-key-header X-API-Key`
+
 ## License
 MIT - [Anh Thang Bui][me]
 

--- a/bin/soap-converter.js
+++ b/bin/soap-converter.js
@@ -29,6 +29,18 @@ program
         isAllowedValue('^(Postman|SwaggerJSON|SwaggerYAML)$')
     )
     .option('-o, --output <file>', 'output file (e.g. ~/output.json)')
+    .option(
+        '-k, --api-key-header <name>',
+        "specify an apiKey header name (e.g. 'X-API-Key')"
+    )
+    .option('--use-security', 'enable generating wssecurity', false)
+    .option(
+        '--use-ibm-datapower-gateway',
+        'enable IBM DataPower Gateway headers',
+        false
+    )
+    .option('--no-examples', 'disable generating examples', false)
+    .option('--no-inline-attributes', 'disable inline attributes', false)
     .action(options => {
         const prompts = []
 

--- a/index.js
+++ b/index.js
@@ -3,10 +3,10 @@ const apiWSDL = require('apiconnect-wsdl')
 const fs = require('fs')
 const converter = require('./converters')
 
-async function convert({ input, output, target }) {
-    debug('convert', input)
+async function convert(options) {
+    debug('convert', options.input)
 
-    const wsdls = await apiWSDL.getJsonForWSDL(input)
+    const wsdls = await apiWSDL.getJsonForWSDL(options.input)
     const serviceData = apiWSDL.getWSDLServices(wsdls)
 
     const items = []
@@ -15,14 +15,44 @@ async function convert({ input, output, target }) {
         const svcName = serviceData.services[item].service
         const wsdlId = serviceData.services[item].filename
         const wsdlEntry = apiWSDL.findWSDLForServiceName(wsdls, svcName)
-        const swagger = apiWSDL.getSwaggerForService(wsdlEntry, svcName, wsdlId)
+
+        const swaggerOptions = {
+            inlineAttributes: options.inlineAttributes,
+            suppressExamples: !options.examples,
+            type: 'wsdl',
+            wssecurity: options.useSecurity
+        }
+
+        const swagger = apiWSDL.getSwaggerForService(
+            wsdlEntry,
+            svcName,
+            wsdlId,
+            swaggerOptions
+        )
+
+        if (!options.useIbmDatapowerGateway) {
+            delete swagger.info['x-ibm-name']
+            delete swagger['x-ibm-configuration']
+        }
+
+        if (options.apiKeyHeader) {
+            swagger.securityDefinitions.clientID.name = options.apiKeyHeader
+
+            if (!options.useIbmDatapowerGateway) {
+                // ApiKeyAuth is more swagger-standard than clientID
+                swagger.securityDefinitions.ApiKeyAuth =
+                    swagger.securityDefinitions.clientID
+                delete swagger.securityDefinitions.clientID
+                swagger.security = [{ ApiKeyAuth: [] }]
+            }
+        }
 
         items.push(swagger)
     }
 
     let isJSONOutput = true
     let out
-    switch (target) {
+    switch (options.target) {
         case 'Postman':
             out = converter.Postman(items)
             break
@@ -34,11 +64,13 @@ async function convert({ input, output, target }) {
             isJSONOutput = false
             break
         default:
-            throw new Error(`output format [${target}] currently not supported`)
+            throw new Error(
+                `output format [${options.target}] currently not supported`
+            )
     }
 
     const data = isJSONOutput ? JSON.stringify(out, null, 2) : out
-    fs.writeFileSync(output, data)
+    fs.writeFileSync(options.output, data)
 }
 
 module.exports = convert


### PR DESCRIPTION


    Usage: soap-converter [options]

    Options:
      -i, --input <url>                               wsdl url (e.g. http://example.com/service.svc?wsdl)
      -t, --target <Postman|SwaggerJSON|SwaggerYAML>  target type
      -o, --output <file>                             output file (e.g. ~/output.json)
      -k, --api-key-header <name>                     specify an apiKey header name (e.g. 'X-API-Key')
      --use-security                                  enable generating wssecurity
      --use-ibm-datapower-gateway                     enable IBM DataPower Gateway headers (default: false)
      --no-examples                                   disable generating examples
      --no-inline-attributes                          disable inline attributes
      -h, --help                                      output usage information